### PR TITLE
Add custom normalization layers

### DIFF
--- a/src/flunet/nn/norm/__init__.py
+++ b/src/flunet/nn/norm/__init__.py
@@ -1,0 +1,1 @@
+from .layer_norm import LayerNorm, PostNorm, PreNorm

--- a/src/flunet/nn/norm/layer_norm.py
+++ b/src/flunet/nn/norm/layer_norm.py
@@ -1,0 +1,116 @@
+import logging
+
+import torch
+from torch import Tensor, nn
+
+# Configure the logger
+logging.basicConfig(level=logging.INFO)
+
+
+class LayerNorm(nn.Module):
+    """A custom Layer Normalization module that normalizes the input tensor over the channel dimension.
+
+    Attributes:
+        dim (int): The number of features in the input tensor.
+        eps (float): A value added to the denominator for numerical stability.
+        g (Tensor): The learnable gain parameters.
+        b (Tensor): The learnable bias parameters.
+    """
+
+    def __init__(self, dim: int, eps: float = 1e-5) -> None:
+        """Initializes the LayerNorm module.
+
+        Args:
+            dim (int): The number of features in the input tensor.
+            eps (float): A value added to the denominator for numerical stability.
+        """
+        super().__init__()
+        if dim <= 0:
+            raise ValueError("The `dim` parameter must be positive.")
+        self.eps = eps
+        self.g = nn.Parameter(torch.ones(1, dim, 1, 1))
+        self.b = nn.Parameter(torch.zeros(1, dim, 1, 1))
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Forward pass for LayerNorm.
+
+        Args:
+            x (Tensor): The input tensor to be normalized.
+
+        Returns:
+            Tensor: The normalized tensor.
+        """
+        if x.dim() != 4:
+            raise ValueError("Expected input with 4 dimensions (batch, channels, height, width)")
+        var = torch.var(x, dim=1, keepdim=True, unbiased=False)
+        mean = torch.mean(x, dim=1, keepdim=True)
+        x_norm = (x - mean) / (var + self.eps).sqrt()
+        return x_norm * self.g + self.b
+
+
+class PreNorm(nn.Module):
+    """Applies Layer Normalization before a module function.
+
+    Attributes:
+        fn (nn.Module): The module function to apply after normalization.
+        norm (LayerNorm): An instance of the LayerNorm module.
+    """
+
+    def __init__(self, dim: int, fn: nn.Module) -> None:
+        """Initializes the PreNorm module.
+
+        Args:
+            dim (int): The number of features in the input tensor for normalization.
+            fn (nn.Module): The module function to apply after normalization.
+        """
+        super().__init__()
+        if not isinstance(fn, nn.Module):
+            raise TypeError("The `fn` argument must be an instance of `nn.Module`.")
+        self.fn = fn
+        self.norm = LayerNorm(dim)
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Forward pass for PreNorm.
+
+        Args:
+            x (Tensor): The input tensor.
+
+        Returns:
+            Tensor: The output tensor after applying normalization and the module function.
+        """
+        x = self.norm(x)
+        return self.fn(x)
+
+
+class PostNorm(nn.Module):
+    """Applies Layer Normalization after a module function.
+
+    Attributes:
+        fn (nn.Module): The module function to apply before normalization.
+        norm (LayerNorm): An instance of the LayerNorm module.
+    """
+
+    def __init__(self, dim: int, fn: nn.Module) -> None:
+        """Initializes the PostNorm module.
+
+        Args:
+            dim (int): The number of features in the input tensor for normalization.
+            fn (nn.Module): The module function to apply before normalization.
+        """
+        super().__init__()
+        if not isinstance(fn, nn.Module):
+            raise TypeError("The `fn` argument must be an instance of `nn.Module`.")
+        self.fn = fn
+        self.norm = LayerNorm(dim)
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Forward pass for PostNorm.
+
+        Args:
+            x (Tensor): The input tensor.
+
+        Returns:
+            Tensor: The output tensor after applying the module function and normalization.
+        """
+        x = self.fn(x)
+        return self.norm(x)

--- a/tests/modules/conftest.py
+++ b/tests/modules/conftest.py
@@ -2,18 +2,24 @@ import pytest
 import torch
 from torch import nn
 
+from flunet.nn.norm import LayerNorm
+
 
 @pytest.fixture(scope="module")
-def simple_model():
-    """Provides a simple linear model from the PyTorch nn module.
+def input_tensor_4d():
+    """Provides a 4-dimensional tensor simulating a batch of multi-channel images, which can be used as input for
+    convolutional layers during tests.
 
-    The fixture creates an instance of the Linear model with predefined input
-    and output features size which is commonly used in tests that require a model.
+    The tensor shape follows the convention (batch_size, channels, height, width),
+    commonly used for image data in convolutional neural networks.
+
+    This fixture generates a batch of 10 tensors, each with 5 channels and
+    spatial dimensions of 10x10, filled with random data.
 
     Returns:
-        nn.Module: A PyTorch Linear model with 10 input features and 2 output features.
+        torch.Tensor: A random 4D tensor of shape (10, 5, 10, 10).
     """
-    return nn.Linear(in_features=10, out_features=2)
+    return torch.randn(10, 5, 10, 10)
 
 
 @pytest.fixture(scope="module")
@@ -30,7 +36,44 @@ def input_tensor():
 
 
 @pytest.fixture(scope="module")
-def model_and_optimizer():
-    model = nn.Linear(10, 2)
-    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
-    return model, optimizer
+def simple_model():
+    """Provides a simple linear model from the PyTorch nn module.
+
+    The fixture creates an instance of the Linear model with predefined input
+    and output features size which is commonly used in tests that require a model.
+
+    Returns:
+        nn.Module: A PyTorch Linear model with 10 input features and 2 output features.
+    """
+    return nn.Linear(in_features=10, out_features=2)
+
+
+@pytest.fixture(scope="module")
+def model_and_optimizer(simple_model):
+    """Provides a simple linear model along with an SGD optimizer, suitable for testing.
+
+    This fixture uses the `simple_model` fixture to create a consistent linear model
+    across tests within the same module. It initializes a Stochastic Gradient Descent (SGD)
+    optimizer with a learning rate of 0.1, which can be used to perform optimization
+    steps during testing.
+
+    The 'module' scope ensures this fixture is only executed once per test module,
+    which means all tests in the module will use the same model and optimizer instances.
+
+    Args:
+        simple_model (nn.Module): A PyTorch Linear model fixture with predefined input/output features.
+
+    Returns:
+        tuple: A tuple containing:
+            - nn.Module: A PyTorch Linear model provided by the `simple_model` fixture.
+            - torch.optim.Optimizer: An SGD optimizer configured for the provided model.
+    """
+    optimizer = torch.optim.SGD(simple_model.parameters(), lr=0.1)
+    return simple_model, optimizer
+
+
+@pytest.fixture
+def layer_norm_module():
+    normalized_shape = (16,)
+    layer_norm = LayerNorm(normalized_shape)
+    return layer_norm

--- a/tests/modules/test_layernorm.py
+++ b/tests/modules/test_layernorm.py
@@ -1,0 +1,128 @@
+import pytest
+import torch
+from torch import nn
+
+from flunet.nn.norm import (  # Replace 'your_module' with the actual name of your module
+    LayerNorm,
+    PostNorm,
+    PreNorm,
+)
+
+# Constants for tests
+DIM = 10
+BATCH_SIZE, CHANNELS, HEIGHT, WIDTH = 2, DIM, 5, 5
+
+
+@pytest.fixture
+def input_tensor_4d():
+    # Arrange
+    return torch.rand(BATCH_SIZE, CHANNELS, HEIGHT, WIDTH)
+
+
+@pytest.fixture
+def mock_conv_module():
+    # Arrange
+    return nn.Conv2d(DIM, DIM, kernel_size=3, padding=1)
+
+
+def test_layer_norm_should_maintain_input_shape(input_tensor_4d):
+    # Arrange
+    layer_norm = LayerNorm(DIM)
+
+    # Act
+    normalized_tensor = layer_norm(input_tensor_4d)
+
+    # Assert
+    assert normalized_tensor.shape == input_tensor_4d.shape
+
+
+def test_layer_norm_should_initialize_parameters_correctly():
+    # Arrange
+    layer_norm = LayerNorm(DIM)
+
+    # Act and Assert
+    assert torch.allclose(layer_norm.g, torch.ones(1, DIM, 1, 1))
+    assert torch.allclose(layer_norm.b, torch.zeros(1, DIM, 1, 1))
+
+
+def test_prenorm_should_apply_module_function_after_normalization(input_tensor_4d, mock_conv_module):
+    # Arrange
+    prenorm = PreNorm(DIM, mock_conv_module)
+
+    # Act
+    output = prenorm(input_tensor_4d)
+
+    # Assert
+    assert output.shape == (BATCH_SIZE, DIM, HEIGHT, WIDTH)
+
+
+def test_postnorm_should_apply_module_function_before_normalization(input_tensor_4d, mock_conv_module):
+    # Arrange
+    postnorm = PostNorm(DIM, mock_conv_module)
+
+    # Act
+    output = postnorm(input_tensor_4d)
+
+    # Assert
+    assert output.shape == (BATCH_SIZE, DIM, HEIGHT, WIDTH)
+
+
+def test_layer_norm_should_raise_value_error_on_invalid_input_shape():
+    # Arrange
+    layer_norm = LayerNorm(DIM)
+    invalid_input = torch.randn(2, DIM)  # Invalid shape, missing two dimensions
+
+    # Act and Assert
+    with pytest.raises(ValueError):
+        layer_norm(invalid_input)
+
+
+def test_layer_norm_should_compute_correct_normalization(input_tensor_4d):
+    # Arrange
+    layer_norm = LayerNorm(DIM)
+
+    # Act
+    output = layer_norm(input_tensor_4d)
+    var = torch.var(input_tensor_4d, dim=1, keepdim=True, unbiased=False)
+    mean = torch.mean(input_tensor_4d, dim=1, keepdim=True)
+    expected_output = (input_tensor_4d - mean) / torch.sqrt(var + layer_norm.eps)
+
+    # Assert
+    assert torch.allclose(output, expected_output * layer_norm.g + layer_norm.b)
+
+
+def test_layer_norm_parameters_should_update_during_training(input_tensor_4d, mock_conv_module):
+    # Arrange
+    layer_norm = LayerNorm(DIM)
+    prenorm = PreNorm(DIM, mock_conv_module)
+    optimizer = torch.optim.SGD(prenorm.parameters(), lr=0.01)
+    loss_fn = nn.MSELoss()
+
+    original_g = layer_norm.g.clone()
+    original_b = layer_norm.b.clone()
+
+    # Act
+    output = prenorm(input_tensor_4d)
+    loss = loss_fn(output, torch.randn_like(output))
+    loss.backward()
+    optimizer.step()
+
+    # Assert
+    updated_g = next(prenorm.norm.parameters())
+    updated_b = next(iter(prenorm.norm.parameters()))
+
+    assert not torch.allclose(updated_g, original_g)
+    assert not torch.allclose(updated_b, original_b)
+
+
+def test_layer_norm_should_handle_zero_variance_case(input_tensor_4d):
+    # Arrange
+    layer_norm = LayerNorm(DIM)
+    input_tensor_4d.fill_(1.0)  # This will have zero variance
+
+    # Act
+    output = layer_norm(input_tensor_4d)
+
+    # Assert
+    # Since the variance is zero, the output should be equal to the bias term.
+    assert torch.allclose(output, layer_norm.b)


### PR DESCRIPTION
## What does this PR do?

This PR introduces three custom normalization classes—LayerNorm, PreNorm, and PostNorm—to our PyTorch toolkit, providing a modular approach to implementing normalization in neural networks. The LayerNorm class applies layer normalization to a mini-batch of inputs, while PreNorm and PostNorm classes allow for normalization to be applied before or after a specified module function, respectively. Comprehensive unit tests have been added to validate the functionality of each class and ensure their reliability.

No dependencies are required for these changes, and there are no breaking changes introduced by this pull request.

Fixes #[TORCH-42](https://jakupsv.atlassian.net/browse/TORCH-42)

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [ ] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃


[TORCH-42]: https://jakupsv.atlassian.net/browse/TORCH-42?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ